### PR TITLE
Integrate with zsh-autosuggestions

### DIFF
--- a/fz.sh
+++ b/fz.sh
@@ -235,6 +235,7 @@ __fz_zsh_completion() {
     LBUFFER="$cmd $selected"
   fi
 
+  type _zsh_autosuggest_clear >/dev/null && _zsh_autosuggest_clear
   zle redisplay
   typeset -f zle-line-init >/dev/null && zle zle-line-init
 }


### PR DESCRIPTION
This makes `fz` work a bit nicer in combination with [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions/) plugin. 

Before (notice the ghost extra `fz` in the end of the pasted path):

![fz-before](https://user-images.githubusercontent.com/1177900/47530463-f61dfb00-d8aa-11e8-8fc3-b06cce24e0bf.gif)

After:

![fz-after](https://user-images.githubusercontent.com/1177900/47530509-0e8e1580-d8ab-11e8-98c1-0e2bb3d79b3b.gif)
