### PR TITLE
Only do bind/redraw-current-line for interactive shells.

### DIFF
--- a/fz.sh
+++ b/fz.sh
@@ -242,8 +242,10 @@ __fz_zsh_completion() {
 }
 
 __fz_init_bash_completion() {
-  # Enable redrawing line by printf '\e[5n'
-  bind '"\e[0n": redraw-current-line'
+  # Enable redrawing line by printf '\e[5n', but only for interactive shells.
+  if [[ "$-" =~ "i" ]]; then
+    bind '"\e[0n": redraw-current-line'
+  fi
 
   complete -o nospace -F __fz_bash_completion "$FZ_CMD"
   complete -o nospace -F __fz_bash_completion "$FZ_SUBDIR_CMD"


### PR DESCRIPTION
The issue
---------

Executing 'scp' to a host where 'fz.sh' is an active Bash completion would
result in the following warning: 'bind: warning: line editing not enabled'.

Solution
--------

Only do the binding for actual interactive shells.

Reference
---------

https://gurdiga.github.io/blog/2018/04/14/bind-warning-line-editing-not-enabled