### PR TITLE
Compatible with z.lua

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -130,6 +130,7 @@ zz [dir name slug]<TAB>
 - `FZ_SUBDIR_TRAVERSAL=0` 關閉子目錄補完。預設為開啟。
 - `FZ_CASE_INSENSITIVE=0` 關閉子目錄補完不限大小寫。預設為開啟。
 - `FZ_ABBREVIATE_HOME=0` 不展開 `~` 變數。預設為展開。
+- `FZ_HISTORY_CD_CMD=_zlua` 同 [z.lua](https://github.com/skywind3000/z.lua) 協同工作。
 
 ## 相關資訊
 
@@ -137,4 +138,5 @@ zz [dir name slug]<TAB>
 - fzf 的[自動完成說明](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh)及其[維基頁面](https://github.com/junegunn/fzf/wiki)
 - [fasd](https://github.com/clvv/fasd)
 - [autojump](https://github.com/wting/autojump)
+- [z.lua](https://github.com/skywind3000/z.lua)
 - [命令行上的narrowing（随着输入逐步减少备选项）工具](http://www.cnblogs.com/bamanzi/p/cli-narrowing-tools.html)

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ zz [dir name slug]<TAB>
 - `FZ_CASE_INSENSITIVE=0` disables case-insensitive subdirectory completion.
     Default is enabled.
 - `FZ_ABBREVIATE_HOME=0` disables abbreviating `~`.  Default is enabled.
+- `FZ_HISTORY_CD_CMD=_zlua` works with [z.lua](https://github.com/skywind3000/z.lua).
 
 ## See Also
 
@@ -154,4 +155,5 @@ zz [dir name slug]<TAB>
     and its [wiki](https://github.com/junegunn/fzf/wiki)
 - [fasd](https://github.com/clvv/fasd)
 - [autojump](https://github.com/wting/autojump)
+- [z.lua](https://github.com/skywind3000/z.lua)
 - [命令行上的narrowing（随着输入逐步减少备选项）工具](http://www.cnblogs.com/bamanzi/p/cli-narrowing-tools.html)

--- a/fz.sh
+++ b/fz.sh
@@ -7,8 +7,13 @@
 [[ -n "$FZ_CMD" ]] || FZ_CMD=z
 [[ -n "$FZ_SUBDIR_CMD" ]] || FZ_SUBDIR_CMD=zz
 
+if [[ -z "$FZ_HISTORY_CD_CMD" ]] && command -v _zlua > /dev/null 2>&1; then
+	command -v _z > /dev/null 2>&1 || FZ_HISTORY_CD_CMD="_zlua"
+fi
+
 [[ -n "$FZ_HISTORY_CD_CMD" ]] || FZ_HISTORY_CD_CMD=_z
-[[ -n "$FZ_SUBDIR_HISTORY_CD_CMD" ]] || FZ_SUBDIR_HISTORY_CD_CMD="_z -c"
+[[ -n "$FZ_SUBDIR_HISTORY_CD_CMD" ]] || \
+	FZ_SUBDIR_HISTORY_CD_CMD="$FZ_HISTORY_CD_CMD -c"
 
 [[ -n "$FZ_HISTORY_LIST_GENERATOR" ]] \
   || FZ_HISTORY_LIST_GENERATOR=__fz_generate_matched_history_list
@@ -94,7 +99,7 @@ __fz_generate_matched_subdir_list() {
 }
 
 __fz_generate_matched_history_list() {
-  _z -l $@ 2>&1 | while read -r line; do
+  "$FZ_HISTORY_CD_CMD" -l $@ 2>&1 | while read -r line; do
     if [[ "$line" == common:* ]]; then continue; fi
     # Reverse the order and cut off the scores
     echo "$line"

--- a/fz.sh
+++ b/fz.sh
@@ -7,10 +7,6 @@
 [[ -n "$FZ_CMD" ]] || FZ_CMD=z
 [[ -n "$FZ_SUBDIR_CMD" ]] || FZ_SUBDIR_CMD=zz
 
-if [[ -z "$FZ_HISTORY_CD_CMD" ]] && command -v _zlua > /dev/null 2>&1; then
-	command -v _z > /dev/null 2>&1 || FZ_HISTORY_CD_CMD="_zlua"
-fi
-
 [[ -n "$FZ_HISTORY_CD_CMD" ]] || FZ_HISTORY_CD_CMD=_z
 [[ -n "$FZ_SUBDIR_HISTORY_CD_CMD" ]] || \
 	FZ_SUBDIR_HISTORY_CD_CMD="$FZ_HISTORY_CD_CMD -c"


### PR DESCRIPTION
With this patch, fz can work with z.lua by:

```bash
FZ_HISTORY_CD_CMD="_zlua"
source "/path/to/fz.sh"
eval "$(lua /path/to/z.lua --init bash enhanced once echo)"
```