### PR TITLE
Use fzf-tmux if using tmux

### DIFF
--- a/fz.sh
+++ b/fz.sh
@@ -161,9 +161,16 @@ __fz_generate_matches() {
   fi
 }
 
+__fz_fzf_prog() {
+  [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] \
+    && echo "fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}" || echo "fzf"
+}
+
 __fz_filter() {
-    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse \
-      --bind 'shift-tab:up,tab:down' $FZF_DEFAULT_OPTS" fzf
+  fzf=$(__fz_fzf_prog)
+
+  FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse \
+    --bind 'shift-tab:up,tab:down' $FZF_DEFAULT_OPTS" ${=fzf}
 }
 
 __fz_bash_completion() {


### PR DESCRIPTION
Hey 👋

What do you think about being able to use `fz` with `tmux`, similar to how you do in [zsh-interactive-cd](https://github.com/changyuheng/zsh-interactive-cd/blob/master/zsh-interactive-cd.plugin.zsh#L9-L11)?

Or am i being naive and this is actually a-lot more complicated than it seems? 😃